### PR TITLE
Remove serde-json from dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,4 @@ phf = { version = "0.8", features = ["macros"] }
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ A library for setting up Rust objects inspired by factory_bot.
 [dependencies]
 beaver = "0.1.0"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 ```
 
 ## Usage
@@ -71,7 +70,6 @@ If you use `chrono`, `Cargo.toml` would look like this.
 [dependencies]
 beaver = "0.1.0"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 # you need `serde` feature.
 chrono = { version = "0.4", features = ["serde"] }
 ```

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -19,13 +19,12 @@ where
     T: Serialize + Deserialize<'a>,
     S: Fn(&mut T, u16),
 {
-    let factory = Factory {
+    Factory {
         model: serde_json::to_string(&model).unwrap(),
         sequence: Cell::new(1),
         gen_func: suite,
         _maker: PhantomData,
-    };
-    factory
+    }
 }
 
 pub fn sequence(from: u16, n: u16) -> u16 {


### PR DESCRIPTION
Since I don't need `serde-json`, I've removed `serde-json` from dependencies.